### PR TITLE
Prevent palette edits from altering segment colors

### DIFF
--- a/led_effect_app/src/components/color/color_palette.py
+++ b/led_effect_app/src/components/color/color_palette.py
@@ -14,10 +14,9 @@ class ColorPaletteComponent(ft.Container):
         self.page = page
         self.action_handler = ColorPaletteActionHandler(page)
         self.current_editing_slot = None
-        
+
         self.content = self.build_content()
-        color_service.add_color_change_listener(self._on_palette_changed)
-        
+
         self.page.on_resize = self._on_page_resize
         
     def build_content(self):

--- a/led_effect_app/src/components/panel/scene_effect_panel.py
+++ b/led_effect_app/src/components/panel/scene_effect_panel.py
@@ -5,6 +5,7 @@ from ..color import ColorPaletteComponent
 from ..region import RegionComponent
 from .scene_effect_action import SceneEffectActionHandler
 from ..data.data_action_handler import DataActionHandler
+from services.color_service import color_service
 
 class SceneEffectPanel(ft.Container):
     """Left panel containing Scene/Effect controls"""
@@ -24,6 +25,7 @@ class SceneEffectPanel(ft.Container):
         scene_settings_section = self._build_scene_settings_section()
 
         self.color_palette = ColorPaletteComponent(self.page)
+        color_service.add_palette_change_listener(self.color_palette._on_palette_changed)
         self.region_settings = RegionComponent(self.page)
         
         return ft.Column([

--- a/led_effect_app/tests/test_palette_change_notifications.py
+++ b/led_effect_app/tests/test_palette_change_notifications.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from services.color_service import color_service
+from services.data_cache import data_cache
+
+
+def test_palette_change_does_not_notify_segment_callbacks():
+    data_cache.set_current_scene(0)
+    color_service.sync_with_cache_palette()
+    color_service.set_current_segment_id("0")
+
+    palette_called = []
+    segment_called = []
+
+    def palette_cb():
+        palette_called.append(True)
+
+    def segment_cb():
+        segment_called.append(True)
+
+    color_service.add_palette_change_listener(palette_cb)
+    color_service.add_color_change_listener(segment_cb)
+
+    original_colors = color_service.get_palette_colors()
+    try:
+        color_service.update_palette_color(0, "#ABCDEF")
+        assert len(palette_called) == 1
+        assert len(segment_called) == 0
+    finally:
+        color_service.update_palette_color(0, original_colors[0])
+        color_service.remove_palette_change_listener(palette_cb)
+        color_service.remove_color_change_listener(segment_cb)


### PR DESCRIPTION
## Summary
- Split `ColorService` change callbacks into palette and segment groups
- Register palette change listener from `SceneEffectPanel` and stop auto-listening inside `ColorPaletteComponent`
- Add regression test ensuring palette updates don't trigger segment callbacks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0022cb198832a8236084c3c94d9d2